### PR TITLE
New Features

### DIFF
--- a/r10kwrapper.spec
+++ b/r10kwrapper.spec
@@ -5,7 +5,7 @@
 %define module_name r10kwrapper
 
 Name:           %{module_name}
-Version:        0.3.1
+Version:        0.3.2
 Release:        1
 Epoch:          2
 Summary:        r10kwrapper - A tool that does a bit of automation and management around the use of the r10k command.
@@ -37,6 +37,12 @@ rm -rf $RPM_BUILD_ROOT
 %attr(0755,-,-) %{_bindir}/r10kwrapper
 
 %changelog
+* Thu Aug 12 2015 Jonathan Kelley <jon.kelley@rackspace.com> 0.3.2
+- Fixed bug in the all_global_hiera ifelse logic
+* Thu Aug 12 2015 Jonathan Kelley <jon.kelley@rackspace.com> 0.3.1
+- Added osmkdir for non existing targets.
+- Added built in config option all_global_hiera, to auto apply all hieras.
+- Added built in config option all_product_hiera, to auto apply all product hieras.
 * Thu Nov 17 2014 Jonathan Kelley <jon.kelley@rackspace.com> 0.1.3
 - Fixed error reporting.
 - Added the ability to fetch a seperate `R10K_BINARY` based on environment.

--- a/r10kwrapper.spec
+++ b/r10kwrapper.spec
@@ -5,7 +5,7 @@
 %define module_name r10kwrapper
 
 Name:           %{module_name}
-Version:        0.3.0
+Version:        0.3.1
 Release:        1
 Epoch:          2
 Summary:        r10kwrapper - A tool that does a bit of automation and management around the use of the r10k command.

--- a/r10kwrapper/r10kwrapper.py
+++ b/r10kwrapper/r10kwrapper.py
@@ -99,7 +99,7 @@ def retrieve_config_sections_from_disk(inifile=wrapper_conf,sections=[]):
                 puppetfile = envvars['puppetfile']
                 module_destination = envvars['moduledest']
                 batch_result.append((puppetfile,module_destination))
-    if 'all_product_hiera' in sections:
+    elif 'all_product_hiera' in sections:
         # This is a magic config param that will execute any CONFIG HEADING with:
         #  *-hiera BUT NOT 'global-hiera'
         for module, envvars in config._sections.items():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[egg_info]
-tag_build = 
-tag_date = 0
-tag_svn_revision = 0
-
 [install]
 optimize = 1
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if __name__ == "__main__":
 
     setup(
         name = NAME,
-        version = "0.3.1",
+        version = "0.3.2",
         author = "Jon Kelley",
         author_email = "jon.kelley@rackspace.com",
         url = "https://github.com/jonkelleyatrackspace/r10kwrapper",

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ if __name__ == "__main__":
 
     setup(
         name = NAME,
-        version = "0.3.0",
+        version = "0.3.1",
         author = "Jon Kelley",
         author_email = "jon.kelley@rackspace.com",
         url = "https://github.com/jonkelleyatrackspace/r10kwrapper",
-        license = 'The FreeBSD Copyright',
+        license = 'Apache License Version 2.0',
         packages = [NAME],
         package_dir = {NAME: NAME},
         description = "r10kwrapper - a wrapper for r10k",


### PR DESCRIPTION
Adding some new features...

* Added a few reserved heading keywords which expand into heading matches within the config file.
  * Passing config heading `all_global_hiera` expands to select any config section that ends with hiera-global, or is global-hiera.
  * Passing config heading `all_product_hiera` expands to slect any config section that ends with -hiera but is not global-hiera.
  * Fixed a bug with the logic above in a separate commit.
* Added a feature which performs `os.mkdir()` if the `puppetfile_dir` targeted does not exist. This could be used to auto invoke new puppet environments for the master.
* Added exception handling for ConfigParser.NoSectionError
* Added exception handling and user-error printing when the r10k binary is missing when subprocess runs.
* Updated version in `.spec`, `setup.py`